### PR TITLE
fix: The IoT custom resource should return the endpoint even on updates

### DIFF
--- a/src/ServerlessSpy.ts
+++ b/src/ServerlessSpy.ts
@@ -88,6 +88,15 @@ export class ServerlessSpy extends Construct {
             endpointType: 'iot:Data-ATS',
           },
         },
+        onUpdate: {
+          service: 'Iot',
+          action: 'describeEndpoint',
+          physicalResourceId:
+            custom_resources.PhysicalResourceId.fromResponse('endpointAddress'),
+          parameters: {
+            endpointType: 'iot:Data-ATS',
+          },
+        },
         installLatestAwsSdk: false,
         policy: custom_resources.AwsCustomResourcePolicy.fromSdkCalls({
           resources: custom_resources.AwsCustomResourcePolicy.ANY_RESOURCE,


### PR DESCRIPTION
When bumping from 2.1.* to 2.2.* in one of our repos the cr suddenly started updating which caused the deploys to fail. The reason is that when it's updating it's not returning the endpoint as it's not making any call.

Fixes #